### PR TITLE
premake fix to use pkg-config to find simavr location

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -41,7 +41,7 @@ kind "ConsoleApp"
 --------------------------------------------------------------------------------
 
 -- Includes
-includedirs { "include", "include/yalla", "include/yalla/device/atmega8", "/usr/include/simavr/avr/"}
+includedirs { "include", "include/yalla", "include/yalla/device/atmega8"}
 -- Enables some additional warnings.
 buildoptions { "-Wall" }
 -- Enables C++11 support.
@@ -50,6 +50,9 @@ buildoptions { "-std=c++14" }
 buildoptions { "-Os " }
 -- set AVR specific options
 buildoptions {"-fpack-struct -fshort-enums -funsigned-char -funsigned-bitfields"}
+
+buildoptions {"`pkg-config --cflags simavr`" }
+
 
 if _OPTIONS["mmcu"] then
   buildoptions { "-mmcu=" .. _OPTIONS["mmcu"] }

--- a/src/test/avr/iomm/iomm_trace.c
+++ b/src/test/avr/iomm/iomm_trace.c
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <avr_mcu_section.h>
+#include <avr/avr_mcu_section.h>
 
 AVR_MCU(8000000, "atmega8");
 

--- a/src/test/avr/register/register_trace.c
+++ b/src/test/avr/register/register_trace.c
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <avr_mcu_section.h>
+#include <avr/avr_mcu_section.h>
 
 AVR_MCU(8000000, "atmega8");
 


### PR DESCRIPTION
Use pkg-config to automatically find simavr include files
